### PR TITLE
proppy: add `onChange` function

### DIFF
--- a/packages/proppy/README.md
+++ b/packages/proppy/README.md
@@ -389,7 +389,7 @@ const P = withTimer(100, (props, providers) => ({
 > onChange(propName, (prop, providers) => props)
 
 > onChange(
->   (prevProps, nextProps) => props,
+>   (prevProps, nextProps) => true,
 >   (props, providers) => props
 > )
 

--- a/packages/proppy/README.md
+++ b/packages/proppy/README.md
@@ -22,6 +22,7 @@
   - [withStateHandlers](#withstatehandlers)
   - [withObservable](#withobservable)
   - [withTimer](#withtimer)
+  - [onChange](#onchange)
   - [map](#map)
   - [shouldUpdate](#shouldupdate)
   - [didSubscribe](#didsubscribe)
@@ -381,6 +382,52 @@ Accessing current props and providers:
 const P = withTimer(100, (props, providers) => ({
   foo: 'foo value',
 }));
+```
+
+## onChange
+
+> onChange(propName, (prop, providers) => props)
+
+> onChange(
+>   (prevProps, nextProps) => props,
+>   (props, providers) => props
+> )
+
+Detect a change in props, and return new props.
+
+**Examples:**
+
+Change `foo`, when `counter` changes:
+
+```js
+const P = compose(
+  withProps({ foo: 'initial foo value' })
+  withState('counter', 'setCounter', 0),
+  onChange('counter', (props, providers) => ({
+    foo: `changed foo with counter ${props.counter}`
+  }))
+);
+
+const p = P();
+console.log(p.props.foo); // `initial foo value`
+
+p.props.setCounter(10);
+console.log(p.props.foo); // `changed foo with counter 10`
+```
+
+Detecting complex changes:
+
+```js
+const P = compose(
+  withState('counter', 'setCounter', 0),
+  onChange(
+    // detect
+    (prevProps, nextProps) => true,
+
+    // return props
+    (props, providers) => props
+  )
+);
 ```
 
 ## map

--- a/packages/proppy/onChange.js
+++ b/packages/proppy/onChange.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/onChange');

--- a/packages/proppy/src/index.ts
+++ b/packages/proppy/src/index.ts
@@ -19,6 +19,7 @@ export { withReducer } from './withReducer';
 export { withState } from './withState';
 export { withStateHandlers } from './withStateHandlers';
 export { withTimer } from './withTimer';
+export { onChange } from './onChange';
 export { didSubscribe } from './didSubscribe';
 export { willDestroy } from './willDestroy';
 export { emit } from './emit';

--- a/packages/proppy/src/onChange.spec.ts
+++ b/packages/proppy/src/onChange.spec.ts
@@ -1,0 +1,28 @@
+/* global describe, test, expect */
+import { compose } from './compose';
+import { withProps } from './withProps';
+import { withState } from './withState';
+import { onChange } from './onChange';
+
+describe('proppy :: onChange', () => {
+  test('is a function', () => {
+    expect(typeof onChange).toEqual('function');
+  });
+
+  test('changes', () => {
+    const P = compose(
+      withProps({ foo: 'initial foo' }),
+      withState('counter', 'setCounter', 0),
+      onChange('counter', (props) => ({
+        foo: `changed foo with counter ${props.counter}`
+      })),
+    );
+    const p = P();
+
+    expect(p.props.foo).toEqual('initial foo');
+    expect(p.props.counter).toEqual(0);
+
+    p.props.setCounter(5);
+    expect(p.props.foo).toEqual('changed foo with counter 1');
+  });
+});

--- a/packages/proppy/src/onChange.spec.ts
+++ b/packages/proppy/src/onChange.spec.ts
@@ -9,7 +9,7 @@ describe('proppy :: onChange', () => {
     expect(typeof onChange).toEqual('function');
   });
 
-  test('changes', () => {
+  test('changes by string', () => {
     const P = compose(
       withProps({ foo: 'initial foo' }),
       withState('counter', 'setCounter', 0),
@@ -23,6 +23,26 @@ describe('proppy :: onChange', () => {
     expect(p.props.counter).toEqual(0);
 
     p.props.setCounter(5);
-    expect(p.props.foo).toEqual('changed foo with counter 1');
+    expect(p.props.foo).toEqual('changed foo with counter 5');
+  });
+
+  test('changes by comparison', () => {
+    const P = compose(
+      withProps({ foo: 'initial foo' }),
+      withState('counter', 'setCounter', 0),
+      onChange(
+        (prevProps, nextProps) => prevProps.counter !== nextProps.counter,
+        (props) => ({
+          foo: `changed foo with counter ${props.counter}`
+        })
+      ),
+    );
+    const p = P();
+
+    expect(p.props.foo).toEqual('initial foo');
+    expect(p.props.counter).toEqual(0);
+
+    p.props.setCounter(5);
+    expect(p.props.foo).toEqual('changed foo with counter 5');
   });
 });

--- a/packages/proppy/src/onChange.ts
+++ b/packages/proppy/src/onChange.ts
@@ -17,7 +17,7 @@ export function onChange(propName, fn): ProppyFactory {
       }
 
       const detector = typeof propName === 'string'
-        ? (p, n) => p[propName] === n[propName]
+        ? (p, n) => p[propName] !== n[propName]
         : propName;
 
       if (detector(this._prevProps, parentProps)) {

--- a/packages/proppy/src/onChange.ts
+++ b/packages/proppy/src/onChange.ts
@@ -1,0 +1,28 @@
+import { ProppyFactory } from './types';
+import { create } from './create';
+
+export function onChange(propName, fn): ProppyFactory {
+  return create({
+    initialize() {
+      this._prevProps = this.props;
+
+      this._i = false;
+    },
+
+    handleReceivedProps(parentProps) {
+      if (!this._i) {
+        this._i = true;
+
+        return;
+      }
+
+      const detector = typeof propName === 'string'
+        ? (p, n) => p[propName] === n[propName]
+        : propName;
+
+      if (detector(this._prevProps, parentProps)) {
+        this.set(fn(parentProps, this.providers));
+      }
+    },
+  });
+}

--- a/site/content/docs/api.md
+++ b/site/content/docs/api.md
@@ -58,6 +58,7 @@ console.log(p.props);
 | [withStateHandlers](../packages/proppy#withstatehandlers)       | [proppy]           | State with handlers         |
 | [withObservable](../packages/proppy#withobservable)             | [proppy]           | Props via Observable        |
 | [withTimer](../packages/proppy#withtimer)                       | [proppy]           | Scheduled async props       |
+| [onChange](../packages/proppy#onchange)                         | [proppy]           | Handle prop changes         |
 | [emit](../packages/proppy#emit)                                 | [proppy]           | Emit props asynchronously   |
 | [map](../packages/proppy#map)                                   | [proppy]           | Map props                   |
 | [shouldUpdate](../packages/proppy#shouldupdate)                 | [proppy]           | [Lifecycle]                 |


### PR DESCRIPTION
## API

> onChange(propName, (prop, providers) => props)

> onChange(
>   (prevProps, nextProps) => true,
>   (props, providers) => props
> )

Detect a change in props, and return new props.

**Examples:**

Change `foo`, when `counter` changes:

```js
const P = compose(
  withProps({ foo: 'initial foo value' })
  withState('counter', 'setCounter', 0),
  onChange('counter', (props, providers) => ({
    foo: `changed foo with counter ${props.counter}`
  }))
);

const p = P();
console.log(p.props.foo); // `initial foo value`

p.props.setCounter(10);
console.log(p.props.foo); // `changed foo with counter 10`
```

Detecting complex changes:

```js
const P = compose(
  withState('counter', 'setCounter', 0),
  onChange(
    // detect
    (prevProps, nextProps) => true,

    // return props
    (props, providers) => props
  )
);
```