### PR TITLE
proppy: return async props from `onChange`

### DIFF
--- a/packages/proppy/README.md
+++ b/packages/proppy/README.md
@@ -393,6 +393,11 @@ const P = withTimer(100, (props, providers) => ({
 >   (props, providers) => props
 > )
 
+> onChange(
+>   propName,
+>   (props, providers, cb) => void
+> )
+
 Detect a change in props, and return new props.
 
 **Examples:**
@@ -426,6 +431,23 @@ const P = compose(
 
     // return props
     (props, providers) => props
+  )
+);
+```
+
+Returning async props:
+
+```js
+const P = compose(
+  withState('counter', 'setCounter', 0),
+  onChange(
+    // detect
+    (prevProps, nextProps) => true,
+
+    // return props by callback
+    (props, providers, cb) => {
+      cb(props);
+    }
   )
 );
 ```

--- a/packages/proppy/src/onChange.spec.ts
+++ b/packages/proppy/src/onChange.spec.ts
@@ -45,4 +45,23 @@ describe('proppy :: onChange', () => {
     p.props.setCounter(5);
     expect(p.props.foo).toEqual('changed foo with counter 5');
   });
+
+  test('changes by string, returning async props', () => {
+    const P = compose(
+      withState('foo', 'setFoo', 'initial foo'),
+      withState('counter', 'setCounter', 0),
+      onChange('counter', (props, providers, cb) => {
+        cb({
+          foo: `changed foo with counter ${props.counter}`
+        });
+      }),
+    );
+    const p = P();
+
+    expect(p.props.foo).toEqual('initial foo');
+    expect(p.props.counter).toEqual(0);
+
+    p.props.setCounter(5);
+    expect(p.props.foo).toEqual('changed foo with counter 5');
+  });
 });

--- a/packages/proppy/src/onChange.ts
+++ b/packages/proppy/src/onChange.ts
@@ -21,7 +21,12 @@ export function onChange(propName, fn): ProppyFactory {
         : propName;
 
       if (detector(this._prevProps, parentProps)) {
-        this.set(fn(parentProps, this.providers));
+        const cb = newProps => this.set(newProps);
+        const result = fn(parentProps, this.providers, cb);
+
+        if (result) {
+          this.set(result);
+        }
       }
     },
   });


### PR DESCRIPTION
(Async example at the bottom)

## API

> onChange(propName, (prop, providers) => props)

> onChange(
>   (prevProps, nextProps) => true,
>   (props, providers) => props
> )

> onChange(
>   propName,
>   (props, providers, cb) => void
> )

Detect a change in props, and return new props.

**Examples:**

Change `foo`, when `counter` changes:

```js
const P = compose(
  withProps({ foo: 'initial foo value' })
  withState('counter', 'setCounter', 0),
  onChange('counter', (props, providers) => ({
    foo: `changed foo with counter ${props.counter}`
  }))
);

const p = P();
console.log(p.props.foo); // `initial foo value`

p.props.setCounter(10);
console.log(p.props.foo); // `changed foo with counter 10`
```

Detecting complex changes:

```js
const P = compose(
  withState('counter', 'setCounter', 0),
  onChange(
    // detect
    (prevProps, nextProps) => true,

    // return props
    (props, providers) => props
  )
);
```

Returning async props:

```js
const P = compose(
  withState('counter', 'setCounter', 0),
  onChange(
    // detect
    (prevProps, nextProps) => true,

    // return props by callback
    (props, providers, cb) => {
      cb(props);
    }
  )
);
```