### PR TITLE
Include src when publishing to npm

### DIFF
--- a/packages/proppy-frint-react/.npmignore
+++ b/packages/proppy-frint-react/.npmignore
@@ -1,5 +1,4 @@
 package-lock.json
 coverage
-src
 dist
 !lib

--- a/packages/proppy-preact/.npmignore
+++ b/packages/proppy-preact/.npmignore
@@ -1,5 +1,4 @@
 package-lock.json
 coverage
-src
 dist
 !lib

--- a/packages/proppy-react/.npmignore
+++ b/packages/proppy-react/.npmignore
@@ -1,5 +1,4 @@
 package-lock.json
 coverage
-src
 dist
 !lib

--- a/packages/proppy-redux/.npmignore
+++ b/packages/proppy-redux/.npmignore
@@ -1,5 +1,4 @@
 package-lock.json
 coverage
-src
 dist
 !lib

--- a/packages/proppy-rx/.npmignore
+++ b/packages/proppy-rx/.npmignore
@@ -1,5 +1,4 @@
 package-lock.json
 coverage
-src
 dist
 !lib

--- a/packages/proppy-vue/.npmignore
+++ b/packages/proppy-vue/.npmignore
@@ -1,5 +1,4 @@
 package-lock.json
 coverage
-src
 dist
 !lib

--- a/packages/proppy/.npmignore
+++ b/packages/proppy/.npmignore
@@ -1,5 +1,4 @@
 package-lock.json
 coverage
-src
 dist
 !lib


### PR DESCRIPTION
Should when using TypeScript, and generating bundles with source maps.